### PR TITLE
Slight CAS utility minirockets buff/rework

### DIFF
--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -362,7 +362,7 @@
 
 /obj/structure/ship_ammo/minirocket/smoke
 	name = "smoke mini rocket stack"
-	desc = "A pack of laser guided smoke mini rockets."
+	desc = "A pack of laser guided cloaking smoke mini rockets."
 	icon_state = "minirocket_smoke"
 	point_cost = 25
 
@@ -372,8 +372,8 @@
 	var/datum/effect_system/expl_particles/P = new
 	P.set_up(4, 0, impact)
 	P.start()
-	var/datum/effect_system/smoke_spread/S = new
-	S.set_up(3, impact)
+	var/datum/effect_system/smoke_spread/tactical/S = new
+	S.set_up(7, impact)// Large radius, but dissipates quickly
 	S.start()
 
 /obj/structure/ship_ammo/minirocket/illumination
@@ -384,7 +384,7 @@
 
 /obj/structure/ship_ammo/minirocket/illumination/detonate_on(turf/impact, attackdir = NORTH)
 	impact.ceiling_debris_check(2)
-	var/turf/offset_impact = pick(range(5, impact))
+	var/turf/offset_impact = pick(range(3, impact))
 	explosion(offset_impact, 0, 0, 2, 2, throw_range = 0)// Smaller explosion to prevent this becoming the PO meta
 	var/datum/effect_system/expl_particles/P = new/datum/effect_system/expl_particles()
 	P.set_up(4, 0, offset_impact)


### PR DESCRIPTION
## About The Pull Request
Smoke minirockets receives large area fast dissipating cloaking smoke. Ilums offset from 5 to 3.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Now there is a reason to use smoke mini's. Ilums on most maps had often issues like landing behind walls, making them lighting actually nothing what is needed most times. (and hit marines with 25% chance, funny)
For example: old 5 radius gives 11x11 square what is ~0.83% hit chance for single tile and 26% for 4x8 corridor. ~2% and ~57% with new.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: It's now easier to hit what you targeting with illumination minirockets.
balance: Never used smoke minirockets receives cloaking smoke.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
